### PR TITLE
Update p06-error-handling.md small fix. '`' shifted

### DIFF
--- a/src/p06-error-handling.md
+++ b/src/p06-error-handling.md
@@ -265,7 +265,7 @@ val content = getURLContent("garbage") recover {
 
 Теперь мы можем спокойно извлечь значение из `Try[Iterator[String]]`. Нам известно,
 что оно определено. Вызов `content.get.foreach(println)` приведёт к печати сообщения
-`Please make sure to enter a valid URL being printed to the console`.
+`Please make sure to enter a valid URL` being printed to the console.
 
 Заключение
 ---------------------------------------------


### PR DESCRIPTION
Small fix in text. You can compare this with https://danielwestheide.com/blog/the-neophytes-guide-to-scala-part-6-error-handling-with-try/